### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ClickUp MCP Server
 
+[![smithery badge](https://smithery.ai/badge/@Nazruden/clickup-mcp-server)](https://smithery.ai/server/@Nazruden/clickup-mcp-server)
+
 A Model Context Protocol server implementation for ClickUp integration, enabling AI assistants to interact with ClickUp workspaces.
 
 ## Quick Start
@@ -25,6 +27,14 @@ A Model Context Protocol server implementation for ClickUp integration, enabling
 2. Restart Claude for Desktop
 
 That's it! The server will be automatically downloaded and started when needed.
+
+### Installing via Smithery
+
+To install ClickUp MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@Nazruden/clickup-mcp-server):
+
+```bash
+npx -y @smithery/cli install @Nazruden/clickup-mcp-server --client claude
+```
 
 ## Environment Variables
 

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,33 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - clickupClientId
+      - clickupClientSecret
+    properties:
+      clickupClientId:
+        type: string
+        description: The OAuth client ID for ClickUp.
+      clickupClientSecret:
+        type: string
+        description: The OAuth client secret for ClickUp.
+      clickupRedirectUri:
+        type: string
+        default: http://localhost:3000/oauth/callback
+        description: The OAuth redirect URI for ClickUp.
+      port:
+        type: number
+        default: 3000
+        description: The port for the server.
+      logLevel:
+        type: string
+        default: info
+        description: The logging level.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    config => ({ command: 'node', args: ['dist/index.js'], env: { CLICKUP_CLIENT_ID: config.clickupClientId, CLICKUP_CLIENT_SECRET: config.clickupClientSecret, CLICKUP_REDIRECT_URI: config.clickupRedirectUri, PORT: config.port.toString(), LOG_LEVEL: config.logLevel } })


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@Nazruden/clickup-mcp-server?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂