### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Model Context Protocol server implementation for ClickUp integration, enabling AI assistants to interact with ClickUp workspaces.
 
+<a href="https://glama.ai/mcp/servers/9a7p2exf6u"><img width="380" height="200" src="https://glama.ai/mcp/servers/9a7p2exf6u/badge" alt="ClickUp Server MCP server" /></a>
+
 ## Quick Start
 
 1. Configure Claude for Desktop:


### PR DESCRIPTION
This PR adds a badge for the [ClickUp MCP Server](https://glama.ai/mcp/servers/9a7p2exf6u) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/9a7p2exf6u"><img width="380" height="200" src="https://glama.ai/mcp/servers/9a7p2exf6u/badge" alt="ClickUp Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.